### PR TITLE
fix: wrong pp calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ command-ids.json
 osu-token.json
 /src/generated/prisma
 *.sql
+scratch

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "lilybird": "^0.7.1",
         "osu-api-extended": "^3.1.12",
         "redis": "^5.7.0",
-        "rosu-pp-js": "3.1.0",
+        "rosu-pp-js": "4.0.1",
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -333,7 +333,7 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "rosu-pp-js": ["rosu-pp-js@3.1.0", "", {}, "sha512-5YR/ar+XKLvAJAEvPhfEeBunDAY/qPFoey9b9ykvbNDR1K6FO77Mj7VblPpVs9O5TFRwecVSvOLFHMaY63l3YA=="],
+    "rosu-pp-js": ["rosu-pp-js@4.0.1", "", {}, "sha512-yEjhglfSrDVV3aBkd61RgaMqdKbLIX3225gkHS67+IboVZwC2PCmbDl7yaBDV4CSQTtkEEhWIpwdhHTJnoVOcQ=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "lilybird": "^0.7.1",
         "osu-api-extended": "^3.1.12",
         "redis": "^5.7.0",
-        "rosu-pp-js": "3.1.0"
+        "rosu-pp-js": "4.0.1"
     },
     "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/src/commands/osu/recent.ts
+++ b/src/commands/osu/recent.ts
@@ -53,7 +53,7 @@ export async function run(ctx: CommandContext) {
         index = ctx.index ?? 0;
     }
 
-    const { user, mods } = (await parseCommandArgs(ctx, mode));
+    const { user, mods } = await parseCommandArgs(ctx, mode);
 
     if (user.type === UserType.FAIL) {
         await ctx.editReply(user.failMessage);
@@ -68,7 +68,7 @@ export async function run(ctx: CommandContext) {
     }
 }
 
-async function getEmbeds(user: SuccessUser, authorId: string, index: number, includeFails: boolean, mods: any): Promise<{ reply: MessageReplyOptions, embedOptions?: PlaysBuilderOptions }> {
+async function getEmbeds(user: SuccessUser, authorId: string, index: number, includeFails: boolean, mods: any): Promise<{ reply: MessageReplyOptions; embedOptions?: PlaysBuilderOptions }> {
     const osuUserRequest = await safeParse(v2.users.details({ user: user.banchoId, mode: user.mode }));
     if (!osuUserRequest.success) {
         return {
@@ -80,7 +80,7 @@ async function getEmbeds(user: SuccessUser, authorId: string, index: number, inc
                         description: `It seems like the user **\`${user.banchoId}\`** doesn't exist! :(`,
                     },
                 ],
-            }
+            },
         };
     }
     const osuUser = osuUserRequest.data;
@@ -97,7 +97,7 @@ async function getEmbeds(user: SuccessUser, authorId: string, index: number, inc
                         description: `It seems like \`${osuUser.username}\` hasn't set any recent plays! :(`,
                     },
                 ],
-            }
+            },
         };
     }
 

--- a/src/embed-builders/beatmap.ts
+++ b/src/embed-builders/beatmap.ts
@@ -29,7 +29,7 @@ export async function beatmapBuilder({ beatmapId, mods }: BeatmapBuilderOptions)
     const performancesAsync = [];
     const accuracyList = [98, 97, 95];
     for (const accuracy of accuracyList) {
-        const performance = getPerformanceResults({ beatmapId, setId: map.mode_int, mapData, accuracy, mods: mods ?? 0 });
+        const performance = getPerformanceResults({ beatmapId, setId: map.mode_int, mapData, accuracy, mods: mods ?? 0, checksum: map.checksum });
         performancesAsync.push(performance);
     }
     const performances = await Promise.all(performancesAsync);

--- a/src/embed-builders/simulate.ts
+++ b/src/embed-builders/simulate.ts
@@ -38,6 +38,7 @@ export async function simulateBuilder({ beatmapId, mods, options }: SimulateBuil
         clockRate: clockRate ?? (bpm && map.bpm ? bpm / map.bpm : undefined),
         accuracy: acc,
         mods: mods ?? 0,
+        checksum: map.checksum,
     });
 
     if (performance === null) {

--- a/src/types/osu.ts
+++ b/src/types/osu.ts
@@ -127,6 +127,7 @@ export interface ScoreStatistics {
     small_bonus?: number;
     small_tick_hit?: number;
     small_tick_miss?: number;
+    slider_tail_hit?: number;
 }
 
 export type ISOTimestamp = string;

--- a/src/types/osu.ts
+++ b/src/types/osu.ts
@@ -164,6 +164,7 @@ export type Score = {
     rank: Rank;
     score?: number;
     total_score?: number;
+    legacy_score_id?: number | null;
     statistics: ScoreStatistics;
     beatmap: Beatmap;
     beatmapset: Beatmapset;

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -50,7 +50,6 @@ export async function getFormattedScore({
     if ("score" in play && play.score !== undefined) {
         totalScore = play.score;
         createdAt = play.created_at ?? "";
-        scoreStatistics = play.statistics;
     } else {
         // handle V2 and leaderboard scores
         if ("user" in play && play.user) {
@@ -59,18 +58,21 @@ export async function getFormattedScore({
         }
         totalScore = play.total_score ?? 0;
         createdAt = play.ended_at ?? "";
-
-        scoreStatistics = {
-            count_300: play.statistics.great ?? 0,
-            count_100: play.statistics.ok ?? 0,
-            count_50: play.statistics.meh ?? 0,
-            count_geki: play.statistics.perfect ?? 0,
-            count_katu: play.statistics.good ?? 0,
-            count_miss: play.statistics.miss ?? 0,
-        };
     }
 
-    const objectsHit = (scoreStatistics.count_300 ?? 0) + (scoreStatistics.count_100 ?? 0) + (scoreStatistics.count_50 ?? 0) + (scoreStatistics.count_miss ?? 0);
+    scoreStatistics = {
+        count_300: play.statistics.count_300 ?? play.statistics.great ?? 0,
+        count_100: play.statistics.count_100 ?? play.statistics.ok ?? 0,
+        count_50: play.statistics.count_50 ?? play.statistics.meh ?? 0,
+        count_geki: play.statistics.count_geki ?? play.statistics.perfect ?? 0,
+        count_katu: play.statistics.count_katu ?? play.statistics.good ?? 0,
+        count_miss: play.statistics.count_miss ?? play.statistics.miss ?? 0,
+        large_tick_hit: play.statistics.large_tick_hit ?? 0,
+        small_tick_hit: play.statistics.small_tick_hit ?? 0,
+        slider_tail_hit: play.statistics.slider_tail_hit ?? 0,
+    };
+
+    const objectsHit = (scoreStatistics.count_300 ?? 0) + (scoreStatistics.count_100 ?? 0) + (scoreStatistics.count_50 ?? 0) + (scoreStatistics.count_miss ?? 0) + (scoreStatistics.count_geki ?? 0) + (scoreStatistics.count_katu ?? 0);
     const performance = await getPerformanceResults({
         hitValues: scoreStatistics,
         beatmapId: beatmap.id,

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -73,14 +73,16 @@ export async function getFormattedScore({
     };
 
     const objectsHit = (scoreStatistics.count_300 ?? 0) + (scoreStatistics.count_100 ?? 0) + (scoreStatistics.count_50 ?? 0) + (scoreStatistics.count_miss ?? 0) + (scoreStatistics.count_geki ?? 0) + (scoreStatistics.count_katu ?? 0);
+
     const performance = await getPerformanceResults({
         hitValues: scoreStatistics,
         beatmapId: beatmap.id,
         play: play as any,
         maxCombo: play.max_combo,
-        objectsHit,
+        passed: play.passed,
         mods: play.mods as any,
         mapData,
+        checksum: beatmap.checksum,
     });
 
     // throw an error if performance doesn't exist.

--- a/src/utils/osu.ts
+++ b/src/utils/osu.ts
@@ -101,6 +101,8 @@ export async function getPerformanceResults({
     mapData?: string;
     objectsHit?: number;
 }): Promise<PerformanceInfo | null> {
+    const isLazer = false;
+
     let rulesetId: number;
     if (typeof play !== "undefined" && "mode_int" in play) rulesetId = play.mode_int;
     else if (typeof play !== "undefined" && "mode" in play) rulesetId = play.ruleset_id;
@@ -143,6 +145,7 @@ export async function getPerformanceResults({
     }).build();
 
     const perfect = new Performance({
+        lazer: isLazer,
         ar: mapSettings?.ar,
         cs: mapSettings?.cs,
         od: mapSettings?.od,
@@ -165,6 +168,7 @@ export async function getPerformanceResults({
     const current = new Performance(
         typeof accuracy === "undefined"
             ? {
+                  lazer: isLazer,
                   mods: modsInt,
                   n100,
                   n300,
@@ -180,6 +184,7 @@ export async function getPerformanceResults({
                   clockRate,
               }
             : {
+                  lazer: isLazer,
                   mods: modsInt,
                   accuracy,
                   misses,
@@ -195,6 +200,7 @@ export async function getPerformanceResults({
     const fc = new Performance(
         typeof accuracy === "undefined"
             ? {
+                  lazer: isLazer,
                   mods: modsInt,
                   n100,
                   n50,
@@ -206,6 +212,7 @@ export async function getPerformanceResults({
                   clockRate,
               }
             : {
+                  lazer: isLazer,
                   mods: modsInt,
                   misses: 0,
                   accuracy,

--- a/src/utils/osu.ts
+++ b/src/utils/osu.ts
@@ -86,7 +86,17 @@ export async function getPerformanceResults({
     accuracy?: number;
     clockRate?: number;
     mapSettings?: { ar?: number; od?: number; cs?: number };
-    hitValues?: { count_100?: number; count_300?: number; count_50?: number; count_geki?: number | null; count_katu?: number | null; count_miss?: number };
+    hitValues?: { 
+        count_100?: number; 
+        count_300?: number; 
+        count_50?: number; 
+        count_geki?: number | null; 
+        count_katu?: number | null; 
+        count_miss?: number; 
+        large_tick_hit?: number; 
+        small_tick_hit?: number; 
+        slider_tail_hit?: number 
+    };
     mods: Array<string> | Array<Mod> | number;
     mapData?: string;
     objectsHit?: number;
@@ -140,7 +150,17 @@ export async function getPerformanceResults({
         clockRate,
     }).calculate(beatmap);
 
-    const { count_100: n100, count_300: n300, count_50: n50, count_geki: nGeki, count_katu: nKatu, count_miss: misses } = hitValues ?? {};
+    const { 
+        count_100: n100, 
+        count_300: n300, 
+        count_50: n50, 
+        count_geki: nGeki, 
+        count_katu: nKatu, 
+        count_miss: misses,
+        large_tick_hit: largeTickHits,
+        small_tick_hit: smallTickHits,
+        slider_tail_hit: sliderEndHits
+    } = hitValues ?? {};
 
     const current = new Performance(
         typeof accuracy === "undefined"
@@ -152,6 +172,9 @@ export async function getPerformanceResults({
                   nGeki: nGeki ?? undefined,
                   nKatu: nKatu ?? undefined,
                   misses,
+                  largeTickHits,
+                  smallTickHits,
+                  sliderEndHits,
                   combo: maxCombo ?? perfect.difficulty.maxCombo,
                   passedObjects: objectsHit,
                   clockRate,
@@ -160,6 +183,9 @@ export async function getPerformanceResults({
                   mods: modsInt,
                   accuracy,
                   misses,
+                  largeTickHits,
+                  smallTickHits,
+                  sliderEndHits,
                   combo: maxCombo ?? perfect.difficulty.maxCombo,
                   passedObjects: objectsHit,
                   clockRate,

--- a/src/utils/osu.ts
+++ b/src/utils/osu.ts
@@ -2,31 +2,14 @@ import { bulkInsertData, getEntry, insertData } from "@utils/database";
 import { Mode } from "@type/osu";
 import { Tables } from "@type/database";
 import { Beatmap, BeatmapAttributesBuilder, Performance } from "rosu-pp-js";
-import { enums } from "osu-api-extended";
 import { ChannelType } from "lilybird";
 import https from "https";
+import crypto from "crypto";
 import type { Score as ScoreDatabase } from "@type/database";
 import type { Message } from "@lilybird/transformers";
 import type { Mod } from "@type/mods";
 import type { PerformanceInfo, Score, LeaderboardScore, GameMode, Rank, ScoreStatistics, Beatmap as BeatmapWeb, LeaderboardScoresRaw } from "@type/osu";
 import type { Client, Embed } from "lilybird";
-
-function getModsEnum(mods: Array<string>, derivativeModsWithOriginal?: boolean): number {
-    return mods.reduce((count, mod) => {
-        if (
-            !["NF", "EZ", "TD", "HD", "HR", "SD", "DT", "RX", "HT", "NC", "FL", "AT", "SO", "AP", "PF", "4K", "5K", "6K", "7K", "8K", "FI", "RD", "CN", "TP", "K9", "KC", "1K", "2K", "3K", "SV2", "MR"].includes(
-                mod,
-            )
-        )
-            return count;
-
-        if (mod === "NC" && derivativeModsWithOriginal) return count + enums.ModsEnum.NC + enums.ModsEnum.DT;
-
-        if (mod === "PF" && derivativeModsWithOriginal) return count + enums.ModsEnum.PF + enums.ModsEnum.SD;
-
-        return count + enums.ModsEnum[mod as keyof typeof enums.ModsEnum];
-    }, 0);
-}
 
 export async function getBeatmapTopScores({ beatmapId, isGlobal, mode, mods }: { beatmapId: number; isGlobal: boolean; mode: GameMode; mods: Array<string> | undefined }): Promise<Array<LeaderboardScore>> {
     const url = new URL(`https://osu.ppy.sh/beatmaps/${beatmapId}/scores`);
@@ -77,7 +60,8 @@ export async function getPerformanceResults({
     hitValues,
     mods,
     mapData,
-    objectsHit,
+    passed,
+    checksum,
 }: {
     play?: Score | LeaderboardScore;
     setId?: number;
@@ -86,49 +70,79 @@ export async function getPerformanceResults({
     accuracy?: number;
     clockRate?: number;
     mapSettings?: { ar?: number; od?: number; cs?: number };
-    hitValues?: { 
-        count_100?: number; 
-        count_300?: number; 
-        count_50?: number; 
-        count_geki?: number | null; 
-        count_katu?: number | null; 
-        count_miss?: number; 
-        large_tick_hit?: number; 
-        small_tick_hit?: number; 
-        slider_tail_hit?: number 
+    hitValues?: {
+        count_100?: number;
+        count_300?: number;
+        count_50?: number;
+        count_geki?: number | null;
+        count_katu?: number | null;
+        count_miss?: number;
+        large_tick_hit?: number;
+        small_tick_hit?: number;
+        slider_tail_hit?: number;
     };
     mods: Array<string> | Array<Mod> | number;
     mapData?: string;
-    objectsHit?: number;
+    /** Whether the play was completed. When false, passedObjects is calculated from hitValues. */
+    passed?: boolean;
+    checksum?: string;
 }): Promise<PerformanceInfo | null> {
-    const isLazer = false;
+    let isLazer = true;
+    if (play && play.legacy_score_id !== null && typeof play.legacy_score_id !== "undefined") {
+        isLazer = false;
+    }
 
     let rulesetId: number;
     if (typeof play !== "undefined" && "mode_int" in play) rulesetId = play.mode_int;
     else if (typeof play !== "undefined" && "mode" in play) rulesetId = play.ruleset_id;
     else rulesetId = setId!;
 
-    mapData ??= (await getEntry(Tables.MAP, beatmapId))?.data ?? (await downloadBeatmap(beatmapId)).contents;
+    checksum ??= play?.beatmap?.checksum;
+
+    if (mapData && checksum) {
+        const localHash = crypto.createHash("md5").update(mapData).digest("hex");
+        if (localHash !== checksum) {
+            mapData = undefined;
+        }
+    }
+
+    if (!mapData) {
+        const entry = await getEntry(Tables.MAP, beatmapId);
+        mapData = entry?.data;
+        if (mapData && checksum) {
+            const localHash = crypto.createHash("md5").update(mapData).digest("hex");
+            if (localHash !== checksum) {
+                mapData = undefined;
+            }
+        }
+    }
+
+    mapData ??= (await downloadBeatmap(beatmapId)).contents;
     if (!mapData) return null;
 
     let modsStringArray: Array<string> = [];
-    let modsInt: number;
-    if (typeof mods === "number") modsInt = mods;
-    else if (isNewMods(mods)) {
-        modsInt = getModsEnum(
-            mods.map((x) => x.acronym),
-            true,
-        );
+    let rosuMods: object | number;
+
+    if (typeof mods === "number") {
+        rosuMods = mods;
+    } else if (isNewMods(mods)) {
+        rosuMods = mods.map((mod) => {
+            if (mod.settings) {
+                return { acronym: mod.acronym, settings: mod.settings };
+            }
+            return { acronym: mod.acronym };
+        });
         for (const mod of mods) {
             if (mod.acronym === "DT" && mod.settings?.speed_change) {
                 clockRate = mod.settings.speed_change;
                 modsStringArray.push(`${mod.acronym}(${clockRate}x)`);
                 continue;
             }
+            if (mod.acronym === "CL") continue;
             modsStringArray.push(mod.acronym);
         }
     } else {
-        modsInt = getModsEnum(mods as Array<string>, true);
+        rosuMods = (mods as Array<string>).map((acronym) => ({ acronym }));
         modsStringArray = mods as Array<string>;
     }
 
@@ -140,7 +154,7 @@ export async function getPerformanceResults({
         ar: mapSettings?.ar,
         cs: mapSettings?.cs,
         od: mapSettings?.od,
-        mods: modsInt,
+        mods: rosuMods,
         clockRate,
     }).build();
 
@@ -149,27 +163,34 @@ export async function getPerformanceResults({
         ar: mapSettings?.ar,
         cs: mapSettings?.cs,
         od: mapSettings?.od,
-        mods: modsInt,
+        mods: rosuMods,
         clockRate,
     }).calculate(beatmap);
 
-    const { 
-        count_100: n100, 
-        count_300: n300, 
-        count_50: n50, 
-        count_geki: nGeki, 
-        count_katu: nKatu, 
+    const {
+        count_100: n100,
+        count_300: n300,
+        count_50: n50,
+        count_geki: nGeki,
+        count_katu: nKatu,
         count_miss: misses,
         large_tick_hit: largeTickHits,
         small_tick_hit: smallTickHits,
-        slider_tail_hit: sliderEndHits
+        slider_tail_hit: sliderEndHits,
     } = hitValues ?? {};
+
+    // Only calculate passedObjects for failed/incomplete plays.
+    // For completed plays, rosu-pp determines object count from the beatmap.
+    let passedObjects: number | undefined;
+    if (passed === false && hitValues) {
+        passedObjects = (hitValues.count_300 ?? 0) + (hitValues.count_100 ?? 0) + (hitValues.count_50 ?? 0) + (hitValues.count_miss ?? 0);
+    }
 
     const current = new Performance(
         typeof accuracy === "undefined"
             ? {
                   lazer: isLazer,
-                  mods: modsInt,
+                  mods: rosuMods,
                   n100,
                   n300,
                   n50,
@@ -180,19 +201,19 @@ export async function getPerformanceResults({
                   smallTickHits,
                   sliderEndHits,
                   combo: maxCombo ?? perfect.difficulty.maxCombo,
-                  passedObjects: objectsHit,
+                  passedObjects,
                   clockRate,
               }
             : {
                   lazer: isLazer,
-                  mods: modsInt,
+                  mods: rosuMods,
                   accuracy,
                   misses,
                   largeTickHits,
                   smallTickHits,
                   sliderEndHits,
                   combo: maxCombo ?? perfect.difficulty.maxCombo,
-                  passedObjects: objectsHit,
+                  passedObjects,
                   clockRate,
               },
     ).calculate(perfect);
@@ -201,7 +222,7 @@ export async function getPerformanceResults({
         typeof accuracy === "undefined"
             ? {
                   lazer: isLazer,
-                  mods: modsInt,
+                  mods: rosuMods,
                   n100,
                   n50,
                   nGeki: nGeki ?? undefined,
@@ -213,7 +234,7 @@ export async function getPerformanceResults({
               }
             : {
                   lazer: isLazer,
-                  mods: modsInt,
+                  mods: rosuMods,
                   misses: 0,
                   accuracy,
                   combo: perfect.difficulty.maxCombo,
@@ -473,7 +494,7 @@ function saveScore(
             },
             {
                 key: "mods",
-                value: play.mods.map(m => typeof m === "object" && m !== null && "acronym" in m ? m.acronym : m).join(""),
+                value: play.mods.map((m) => (typeof m === "object" && m !== null && "acronym" in m ? m.acronym : m)).join(""),
             },
             {
                 key: "score",

--- a/src/utils/osu.ts
+++ b/src/utils/osu.ts
@@ -83,7 +83,6 @@ export async function getPerformanceResults({
     };
     mods: Array<string> | Array<Mod> | number;
     mapData?: string;
-    /** Whether the play was completed. When false, passedObjects is calculated from hitValues. */
     passed?: boolean;
     checksum?: string;
 }): Promise<PerformanceInfo | null> {


### PR DESCRIPTION
fixes #207 

- updated rosu-pp-js
- pass mods as objects instead of bitflags (preserves CL and DT settings)
- detect stable scores via legacy_score_id and use lazer: false accordingly
- validate cached beatmap checksum, redownload if stale
- only set passedObjects for failed plays