### PR TITLE
Fetch 200 user scores across pages

### DIFF
--- a/src/commands/osu/recent.ts
+++ b/src/commands/osu/recent.ts
@@ -6,7 +6,7 @@ import { CommandData } from "@type/commands";
 import { Mode, PlayType } from "@type/osu";
 import { parseCommandArgs } from "@utils/args";
 import { createPaginationActionRow } from "@utils/pagination";
-import { getUserScores } from "@utils/score-api";
+import { getUserScores, USER_SCORE_FETCH_LIMIT } from "@utils/score-api";
 import { v2 } from "osu-api-extended";
 import { safeParse } from "@utils/safe-parse";
 import { ApplicationCommandOptionType, EmbedType } from "lilybird";
@@ -85,7 +85,7 @@ async function getEmbeds(user: SuccessUser, authorId: string, index: number, inc
     }
     const osuUser = osuUserRequest.data;
 
-    const plays = await getUserScores(osuUser.id, PlayType.RECENT, { query: { mode: user.mode, limit: 200, include_fails: includeFails } }, user.authorDb);
+    const plays = await getUserScores(osuUser.id, PlayType.RECENT, { query: { mode: user.mode, limit: USER_SCORE_FETCH_LIMIT, include_fails: includeFails } }, user.authorDb);
 
     if (plays.length === 0) {
         return {
@@ -150,7 +150,7 @@ export const data = {
                 name: "index",
                 description: "Specify an index, defaults to 1.",
                 min_value: 1,
-                max_value: 200,
+                max_value: USER_SCORE_FETCH_LIMIT,
             },
             {
                 type: ApplicationCommandOptionType.STRING,

--- a/src/commands/osu/recentbest.ts
+++ b/src/commands/osu/recentbest.ts
@@ -5,8 +5,8 @@ import { SuccessUser, UserType } from "@type/command-args";
 import { CommandData } from "@type/commands";
 import { Mode, PlayType } from "@type/osu";
 import { parseCommandArgs } from "@utils/args";
-import { createPaginationActionRow } from "@utils/pagination";
-import { getUserScores } from "@utils/score-api";
+import { createPaginationActionRow, ITEMS_PER_PAGE } from "@utils/pagination";
+import { getUserScores, USER_SCORE_FETCH_LIMIT } from "@utils/score-api";
 import { v2 } from "osu-api-extended";
 import { safeParse } from "@utils/safe-parse";
 import { ApplicationCommandOptionType, EmbedType } from "lilybird";
@@ -88,7 +88,7 @@ async function getEmbeds(
     }
     const osuUser = osuUserRequest.data;
 
-    const plays = await getUserScores(osuUser.id, PlayType.BEST, { query: { mode: user.mode, limit: 200 } }, user.authorDb);
+    const plays = await getUserScores(osuUser.id, PlayType.BEST, { query: { mode: user.mode, limit: USER_SCORE_FETCH_LIMIT } }, user.authorDb);
 
     if (plays.length === 0) {
         return {
@@ -156,14 +156,14 @@ export const data = {
                 name: "index",
                 description: "Specify an index.",
                 min_value: 1,
-                max_value: 200,
+                max_value: USER_SCORE_FETCH_LIMIT,
             },
             {
                 type: ApplicationCommandOptionType.INTEGER,
                 name: "page",
                 description: "Specify a page, defaults to 1.",
                 min_value: 1,
-                max_value: 20,
+                max_value: Math.ceil(USER_SCORE_FETCH_LIMIT / ITEMS_PER_PAGE),
             },
             {
                 type: ApplicationCommandOptionType.STRING,

--- a/src/commands/osu/recentlist.ts
+++ b/src/commands/osu/recentlist.ts
@@ -5,8 +5,8 @@ import { SuccessUser, UserType } from "@type/command-args";
 import { CommandData } from "@type/commands";
 import { Mode, PlayType } from "@type/osu";
 import { parseCommandArgs } from "@utils/args";
-import { createPaginationActionRow } from "@utils/pagination";
-import { getUserScores } from "@utils/score-api";
+import { createPaginationActionRow, ITEMS_PER_PAGE } from "@utils/pagination";
+import { getUserScores, USER_SCORE_FETCH_LIMIT } from "@utils/score-api";
 import { v2 } from "osu-api-extended";
 import { safeParse } from "@utils/safe-parse";
 import { ApplicationCommandOptionType, EmbedType } from "lilybird";
@@ -104,7 +104,7 @@ async function getEmbeds(
     }
     const osuUser = osuUserRequest.data;
 
-    const plays = await getUserScores(osuUser.id, PlayType.RECENT, { query: { mode: user.mode, limit: 200, include_fails: includeFails } }, user.authorDb);
+    const plays = await getUserScores(osuUser.id, PlayType.RECENT, { query: { mode: user.mode, limit: USER_SCORE_FETCH_LIMIT, include_fails: includeFails } }, user.authorDb);
 
     if (plays.length === 0) {
         return {
@@ -171,14 +171,14 @@ export const data = {
                 name: "index",
                 description: "Specify an index, defaults to 1.",
                 min_value: 1,
-                max_value: 200,
+                max_value: USER_SCORE_FETCH_LIMIT,
             },
             {
                 type: ApplicationCommandOptionType.INTEGER,
                 name: "page",
                 description: "Specify a page, defaults to 1.",
                 min_value: 1,
-                max_value: 20,
+                max_value: Math.ceil(USER_SCORE_FETCH_LIMIT / ITEMS_PER_PAGE),
             },
             {
                 type: ApplicationCommandOptionType.STRING,

--- a/src/commands/osu/top.ts
+++ b/src/commands/osu/top.ts
@@ -5,8 +5,8 @@ import { SuccessUser, UserType } from "@type/command-args";
 import { CommandData } from "@type/commands";
 import { Mode, PlayType } from "@type/osu";
 import { parseCommandArgs } from "@utils/args";
-import { createPaginationActionRow } from "@utils/pagination";
-import { getUserScores } from "@utils/score-api";
+import { createPaginationActionRow, ITEMS_PER_PAGE } from "@utils/pagination";
+import { getUserScores, USER_SCORE_FETCH_LIMIT } from "@utils/score-api";
 import { v2 } from "osu-api-extended";
 import { safeParse } from "@utils/safe-parse";
 import { ApplicationCommandOptionType, EmbedType } from "lilybird";
@@ -84,7 +84,7 @@ async function getEmbeds(
     }
     const osuUser = osuUserRequest.data;
 
-    const plays = await getUserScores(osuUser.id, PlayType.BEST, { query: { mode: user.mode, limit: 200 } }, user.authorDb);
+    const plays = await getUserScores(osuUser.id, PlayType.BEST, { query: { mode: user.mode, limit: USER_SCORE_FETCH_LIMIT } }, user.authorDb);
 
     if (plays.length === 0) {
         return {
@@ -151,14 +151,14 @@ export const data = {
                 name: "index",
                 description: "Specify an index.",
                 min_value: 1,
-                max_value: 200,
+                max_value: USER_SCORE_FETCH_LIMIT,
             },
             {
                 type: ApplicationCommandOptionType.INTEGER,
                 name: "page",
                 description: "Specify a page, defaults to 1.",
                 min_value: 1,
-                max_value: 20,
+                max_value: Math.ceil(USER_SCORE_FETCH_LIMIT / ITEMS_PER_PAGE),
             },
             {
                 type: ApplicationCommandOptionType.STRING,

--- a/src/commands/osu/whatif.ts
+++ b/src/commands/osu/whatif.ts
@@ -5,7 +5,7 @@ import { EmbedBuilderType } from "@type/builders";
 import { Mode, PlayType } from "@type/osu";
 import { parseCommandArgs } from "@utils/args";
 import { CommandContext } from "@utils/command-context";
-import { getUserScores } from "@utils/score-api";
+import { getUserScores, USER_SCORE_FETCH_LIMIT } from "@utils/score-api";
 import { safeParse } from "@utils/safe-parse";
 import { calculateWhatIfProjection, estimateGlobalRankFromPp, extractWhatIfPlayPps, parseWhatIfPlayPps, WhatIfValidationError } from "@utils/whatif";
 import { ApplicationCommandOptionType, EmbedType } from "lilybird";
@@ -94,7 +94,7 @@ async function getEmbeds(user: SuccessUser, playPps: Array<number>, initiatorId:
     }
 
     const osuUser = osuUserRequest.data as UserExtended;
-    const scores = await getUserScores(osuUser.id, PlayType.BEST, { query: { mode: user.mode, limit: 100 } }, user.authorDb);
+    const scores = await getUserScores(osuUser.id, PlayType.BEST, { query: { mode: user.mode, limit: USER_SCORE_FETCH_LIMIT } }, user.authorDb);
     const currentPlayPps = scores.map((score) => score.pp).filter((pp): pp is number => typeof pp === "number");
     const currentTotalPp = osuUser.statistics.pp;
     const projection = calculateWhatIfProjection(currentTotalPp, currentPlayPps, playPps);

--- a/src/commands/osu/whatif.ts
+++ b/src/commands/osu/whatif.ts
@@ -15,6 +15,10 @@ import { UserType } from "@type/command-args";
 import type { UserExtended } from "@type/osu";
 
 const modeAliases: Record<string, Mode> = {
+    wi: Mode.OSU,
+    wit: Mode.TAIKO,
+    wim: Mode.MANIA,
+    wic: Mode.FRUITS,
     whatif: Mode.OSU,
     whatift: Mode.TAIKO,
     whatiftaiko: Mode.TAIKO,

--- a/src/utils/score-api.ts
+++ b/src/utils/score-api.ts
@@ -2,23 +2,46 @@ import { v2 } from "osu-api-extended";
 import { type User } from "@type/database";
 import type { Score, PlayType, Mode } from "@type/osu";
 
+export const USER_SCORE_FETCH_LIMIT = 200;
+const USER_SCORE_API_PAGE_LIMIT = 100;
+
+interface UserScoresOptions {
+    query: {
+        mode: Mode;
+        limit: number;
+        include_fails?: boolean;
+    };
+}
+
 // Gets user scores using V2 unified format
-export async function getUserScores(userId: number, type: PlayType, options: { query: { mode: Mode; limit: number; include_fails?: boolean } }, _authorDb: User | null): Promise<Array<Score>> {
+export async function getUserScores(userId: number, type: PlayType, options: UserScoresOptions, _authorDb: User | null): Promise<Array<Score>> {
     const apiType = type === "best" ? "user_best" : type === "recent" ? "user_recent" : "user_firsts";
+    const requestedLimit = options.query.limit;
+    const scores: Array<Score> = [];
 
-    const scores = await v2.scores.list({
-        type: apiType,
-        user_id: userId,
-        mode: options.query.mode,
-        limit: options.query.limit,
-        include_fails: options.query.include_fails,
-    });
+    while (scores.length < requestedLimit) {
+        const remainingLimit = requestedLimit - scores.length;
+        const pageLimit = Math.min(remainingLimit, USER_SCORE_API_PAGE_LIMIT);
+        const pageOffset = scores.length;
+        const page = await v2.scores.list({
+            type: apiType,
+            user_id: userId,
+            mode: options.query.mode,
+            limit: pageLimit,
+            offset: pageOffset === 0 ? undefined : pageOffset,
+            include_fails: options.query.include_fails,
+        });
 
-    if ("error" in scores || !Array.isArray(scores)) {
-        throw new Error(scores.error?.message ?? "Failed to fetch user scores");
+        if ("error" in page || !Array.isArray(page)) {
+            throw new Error(page.error?.message ?? "Failed to fetch user scores");
+        }
+
+        const pageScores = page as Array<Score>;
+        scores.push(...pageScores);
+        if (pageScores.length < pageLimit) break;
     }
 
-    return (scores as Array<Score>).map((score, index) => ({ ...score, position: index + 1 }));
+    return scores.slice(0, requestedLimit).map((score, index) => ({ ...score, position: index + 1 }));
 }
 
 // Gets beatmap user scores using V2 unified format

--- a/tests/commands/osu/recent.test.ts
+++ b/tests/commands/osu/recent.test.ts
@@ -30,6 +30,9 @@ mock.module("@utils/database", () => ({
 }));
 
 mock.module("osu-api-extended", () => ({
+    enums: {
+        ModsEnum: {},
+    },
     v2: {
         users: {
             details: mock(({ user }: { user: string }) =>
@@ -40,6 +43,7 @@ mock.module("osu-api-extended", () => ({
 }));
 
 mock.module("@utils/score-api", () => ({
+    USER_SCORE_FETCH_LIMIT: 200,
     getUserScores: mock(() => Promise.resolve([{ id: 1, mods: [], statistics: {}, beatmap: { id: 1 }, beatmapset: {}, passed: true }])),
 }));
 

--- a/tests/commands/osu/top.test.ts
+++ b/tests/commands/osu/top.test.ts
@@ -30,6 +30,9 @@ mock.module("@utils/database", () => ({
 }));
 
 mock.module("osu-api-extended", () => ({
+    enums: {
+        ModsEnum: {},
+    },
     v2: {
         users: {
             details: mock(({ user }: { user: string }) =>
@@ -40,6 +43,7 @@ mock.module("osu-api-extended", () => ({
 }));
 
 mock.module("@utils/score-api", () => ({
+    USER_SCORE_FETCH_LIMIT: 200,
     getUserScores: mock(() => Promise.resolve([{ id: 1, mods: [], statistics: {}, beatmap: { id: 1 }, beatmapset: {}, passed: true }])),
 }));
 
@@ -55,9 +59,21 @@ mock.module("@builders", () => ({
     ]),
 }));
 
-const { run } = await import("../../../src/commands/osu/top");
+const { run, data: topData } = await import("../../../src/commands/osu/top");
+const { data: recentBestData } = await import("../../../src/commands/osu/recentbest");
+const { data: recentListData } = await import("../../../src/commands/osu/recentlist");
+
+function getPageMaxValue(commandData: { application: { options: Array<{ name: string; max_value?: number }> } }): number | undefined {
+    return commandData.application.options.find((option) => option.name === "page")?.max_value;
+}
 
 describe("top command", () => {
+    test("allows selecting pages for all fetched top plays", () => {
+        expect(getPageMaxValue(topData)).toBe(40);
+        expect(getPageMaxValue(recentBestData)).toBe(40);
+        expect(getPageMaxValue(recentListData)).toBe(40);
+    });
+
     test("runs with mocked osu data and returns paginated embeds", async () => {
         const mockClient = { rest: {} } as unknown as Client;
         const reply = mock((_options: ReplyPayload) => Promise.resolve({ edit: mock(() => Promise.resolve({})) }));

--- a/tests/commands/osu/whatif.test.ts
+++ b/tests/commands/osu/whatif.test.ts
@@ -54,13 +54,16 @@ mock.module("osu-api-extended", () => ({
     },
 }));
 
+const getUserScoresMock = mock((_userId: number, _type: unknown, _options: unknown, _authorDb: unknown) =>
+    Promise.resolve([
+        { id: 1, pp: 500 },
+        { id: 2, pp: 400 },
+    ]),
+);
+
 mock.module("@utils/score-api", () => ({
-    getUserScores: mock(() =>
-        Promise.resolve([
-            { id: 1, pp: 500 },
-            { id: 2, pp: 400 },
-        ]),
-    ),
+    USER_SCORE_FETCH_LIMIT: 200,
+    getUserScores: getUserScoresMock,
 }));
 
 const { run } = await import("../../../src/commands/osu/whatif");
@@ -94,6 +97,7 @@ describe("whatif command", () => {
             expect(replyCall.embeds[0].description).toContain("1,408.50pp");
             expect(replyCall.embeds[0].description).toContain("#2");
             expect(replyCall.embeds[0].fields?.[0]?.value).toContain("+`408.50pp`");
+            expect(getUserScoresMock.mock.calls[0]?.[2]).toEqual({ query: { mode: "osu", limit: 200 } });
         } finally {
             globalThis.fetch = originalFetch;
             if (typeof originalApiKey === "undefined") Reflect.deleteProperty(process.env, "OSU_DAILY_API");

--- a/tests/commands/osu/whatif.test.ts
+++ b/tests/commands/osu/whatif.test.ts
@@ -66,9 +66,16 @@ mock.module("@utils/score-api", () => ({
     getUserScores: getUserScoresMock,
 }));
 
-const { run } = await import("../../../src/commands/osu/whatif");
+const { run, data } = await import("../../../src/commands/osu/whatif");
 
 describe("whatif command", () => {
+    test("includes short prefix aliases for all modes", () => {
+        expect(data.message.aliases).toContain("wi");
+        expect(data.message.aliases).toContain("wit");
+        expect(data.message.aliases).toContain("wim");
+        expect(data.message.aliases).toContain("wic");
+    });
+
     test("projects pp and rank from prefix pp values", async () => {
         const originalApiKey = process.env.OSU_DAILY_API;
         const originalFetch = globalThis.fetch;
@@ -102,6 +109,34 @@ describe("whatif command", () => {
             globalThis.fetch = originalFetch;
             if (typeof originalApiKey === "undefined") Reflect.deleteProperty(process.env, "OSU_DAILY_API");
             else process.env.OSU_DAILY_API = originalApiKey;
+        }
+    });
+
+    test("routes short mode aliases to the matching osu mode", async () => {
+        const mockClient = { rest: {} } as unknown as Client;
+        const reply = mock((_options: ReplyPayload) => Promise.resolve({ edit: mock(() => Promise.resolve({})) }));
+        const mockMessage = {
+            author: { id: "123", username: "test_user" },
+            guildId: "guild",
+            channelId: "channel123",
+            reply,
+        } as unknown as Message;
+
+        const modeCases = [
+            ["wi", "osu"],
+            ["wit", "taiko"],
+            ["wim", "mania"],
+            ["wic", "fruits"],
+        ] as const;
+
+        for (const [commandName, mode] of modeCases) {
+            const callCount = getUserScoresMock.mock.calls.length;
+            const ctx = new CommandContext(mockClient, undefined, mockMessage, ["450pp", "mrekk"], "!", commandName);
+            ctx.defer = mock(() => Promise.resolve());
+
+            await run(ctx);
+
+            expect(getUserScoresMock.mock.calls[callCount]?.[2]).toEqual({ query: { mode, limit: 200 } });
         }
     });
 });

--- a/tests/embed-builders/plays.test.ts
+++ b/tests/embed-builders/plays.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, mock, test } from "bun:test";
+import { EmbedBuilderType } from "../../src/types/builders";
+import { Mode } from "../../src/types/osu";
+
+const saveScoreDatasMock = mock(() => Promise.resolve());
+
+mock.module("@utils/osu", () => ({
+    saveScoreDatas: saveScoreDatasMock,
+}));
+
+mock.module("@utils/formatter", () => ({
+    getFormattedProfile: mock(() => ({
+        username: "yorunoken",
+        pp: "10,021.3",
+        globalRank: "8,083",
+        countryCode: "TR",
+        countryRank: "61",
+        userUrl: "https://osu.ppy.sh/users/1",
+        avatarUrl: "https://a.ppy.sh/1",
+        flagUrl: "https://osu.ppy.sh/images/flags/TR.png",
+    })),
+    getFormattedScore: mock(({ index }: { index: number }) =>
+        Promise.resolve({
+            position: index + 1,
+            songName: `Song ${index + 1}`,
+            difficultyName: "Expert",
+            mapLink: `https://osu.ppy.sh/beatmaps/${index + 1}`,
+            mods: ["HR"],
+            stars: "8.00★",
+            grade: "A",
+            ppFormatted: "500.00pp",
+            score: "1,000,000",
+            accuracy: "99.00",
+            hitValues: "500/0/0",
+            comboValues: "1,000/1,000x",
+            playSubmitted: "1 day ago",
+        }),
+    ),
+}));
+
+const { playBuilder } = await import("../../src/embed-builders/plays");
+
+describe("plays embed builder", () => {
+    test("uses all fetched plays when calculating top command page count", async () => {
+        const plays = Array.from({ length: 200 }, (_value, index) => ({ id: index + 1 }));
+
+        const embeds = await playBuilder({
+            type: EmbedBuilderType.PLAYS,
+            initiatorId: "user-1",
+            user: { id: 1, username: "yorunoken" },
+            mode: Mode.OSU,
+            authorDb: null,
+            isMultiple: true,
+            isPage: true,
+            page: 0,
+            plays,
+        } as never);
+
+        expect(saveScoreDatasMock).toHaveBeenCalledWith(plays, Mode.OSU);
+        expect(embeds[0]?.footer?.text).toBe("Page 1 of 40");
+        expect(embeds[0]?.description).toContain("#1");
+        expect(embeds[0]?.description).toContain("#5");
+    });
+});

--- a/tests/utils/score-api.test.ts
+++ b/tests/utils/score-api.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, mock, test } from "bun:test";
+import { Mode, PlayType } from "../../src/types/osu";
+
+const listScoresMock = mock(({ offset }: { offset?: number }) => {
+    const start = offset ?? 0;
+    return Promise.resolve(Array.from({ length: 100 }, (_value, index) => ({ id: start + index + 1 })));
+});
+
+mock.module("osu-api-extended", () => ({
+    enums: {
+        ModsEnum: {},
+    },
+    v2: {
+        scores: {
+            list: listScoresMock,
+        },
+    },
+}));
+
+const { getUserScores } = await import("../../src/utils/score-api");
+
+describe("score API utilities", () => {
+    test("fetches user scores in offset pages when more than 100 are requested", async () => {
+        const scores = await getUserScores(1, PlayType.BEST, { query: { mode: Mode.OSU, limit: 200 } }, null);
+
+        expect(scores).toHaveLength(200);
+        expect(scores[0]?.position).toBe(1);
+        expect(scores[199]?.position).toBe(200);
+        expect(listScoresMock).toHaveBeenCalledTimes(2);
+        expect(listScoresMock.mock.calls[0]?.[0]).toMatchObject({ type: "user_best", user_id: 1, mode: "osu", limit: 100 });
+        expect(listScoresMock.mock.calls[0]?.[0].offset).toBeUndefined();
+        expect(listScoresMock.mock.calls[1]?.[0]).toMatchObject({ type: "user_best", user_id: 1, mode: "osu", limit: 100, offset: 100 });
+    });
+});


### PR DESCRIPTION
Closes #231.

Fetches up to 200 user scores by paging the osu! user score endpoint with offsets, so top/recent/recentbest/recentlist/whatif can use the full available score window. Updates paged slash command limits to expose 40 pages and adds short whatif aliases for all modes: wi, wit, wim, and wic.

Checked with `bun test` and `bun run check`.