### PR TITLE
Add score title filters

### DIFF
--- a/src/commands/osu/recent.ts
+++ b/src/commands/osu/recent.ts
@@ -53,14 +53,15 @@ export async function run(ctx: CommandContext) {
         index = ctx.index ?? 0;
     }
 
-    const { user, mods } = await parseCommandArgs(ctx, mode);
+    const { user, mods, flags } = await parseCommandArgs(ctx, mode);
 
     if (user.type === UserType.FAIL) {
         await ctx.editReply(user.failMessage);
         return;
     }
 
-    const { reply, embedOptions } = await getEmbeds(user, ctx.user.id, index, includeFails, mods);
+    const titleFilter = flags.filter?.trim() || undefined;
+    const { reply, embedOptions } = await getEmbeds(user, ctx.user.id, index, includeFails, mods, titleFilter);
     if (embedOptions) {
         await ctx.sendWithPagination(reply, embedOptions);
     } else {
@@ -68,7 +69,14 @@ export async function run(ctx: CommandContext) {
     }
 }
 
-async function getEmbeds(user: SuccessUser, authorId: string, index: number, includeFails: boolean, mods: any): Promise<{ reply: MessageReplyOptions; embedOptions?: PlaysBuilderOptions }> {
+async function getEmbeds(
+    user: SuccessUser,
+    authorId: string,
+    index: number,
+    includeFails: boolean,
+    mods: any,
+    titleFilter: string | undefined,
+): Promise<{ reply: MessageReplyOptions; embedOptions?: PlaysBuilderOptions }> {
     const osuUserRequest = await safeParse(v2.users.details({ user: user.banchoId, mode: user.mode }));
     if (!osuUserRequest.success) {
         return {
@@ -111,6 +119,7 @@ async function getEmbeds(user: SuccessUser, authorId: string, index: number, inc
         index,
         isPage: false,
         mods,
+        titleFilter,
     };
 
     const embeds = await playBuilder(embedOptions);
@@ -182,6 +191,11 @@ export const data = {
                 name: "grade",
                 description: "Consider scores only with this grade.",
                 choices: ["SS", "S", "A", "B", "C", "D"].map((grade) => ({ name: grade, value: grade })),
+            },
+            {
+                type: ApplicationCommandOptionType.STRING,
+                name: "filter",
+                description: "Filter plays by beatmap title.",
             },
             {
                 type: ApplicationCommandOptionType.BOOLEAN,

--- a/src/commands/osu/recentbest.ts
+++ b/src/commands/osu/recentbest.ts
@@ -56,7 +56,8 @@ export async function run(ctx: CommandContext) {
     if (typeof page === "undefined" && typeof index === "undefined") page = 0;
     const isPage = typeof page !== "undefined";
 
-    const { reply, embedOptions } = await getEmbeds(user, ctx.user.id, index, page, isPage, mods);
+    const titleFilter = flags.filter?.trim() || undefined;
+    const { reply, embedOptions } = await getEmbeds(user, ctx.user.id, index, page, isPage, mods, titleFilter);
     if (embedOptions) {
         await ctx.sendWithPagination(reply, embedOptions);
     } else {
@@ -71,6 +72,7 @@ async function getEmbeds(
     page: number | undefined,
     isPage: boolean,
     mods: any,
+    titleFilter: string | undefined,
 ): Promise<{ reply: MessageReplyOptions; embedOptions?: PlaysBuilderOptions }> {
     const osuUserRequest = await safeParse(v2.users.details({ user: user.banchoId, mode: user.mode }));
     if (!osuUserRequest.success) {
@@ -116,6 +118,7 @@ async function getEmbeds(
         page,
         index,
         mods,
+        titleFilter,
         plays,
     };
 
@@ -195,6 +198,11 @@ export const data = {
                 name: "grade",
                 description: "Consider scores only with this grade.",
                 choices: ["SS", "S", "A", "B", "C", "D"].map((grade) => ({ name: grade, value: grade })),
+            },
+            {
+                type: ApplicationCommandOptionType.STRING,
+                name: "filter",
+                description: "Filter plays by beatmap title.",
             },
             {
                 type: ApplicationCommandOptionType.USER,

--- a/src/commands/osu/recentlist.ts
+++ b/src/commands/osu/recentlist.ts
@@ -71,7 +71,8 @@ export async function run(ctx: CommandContext) {
     if (typeof page === "undefined" && typeof index === "undefined") page = 0;
     const isPage = typeof page !== "undefined";
 
-    const { reply, embedOptions } = await getEmbeds(user, ctx.user.id, index, page, isPage, mods, includeFails);
+    const titleFilter = flags.filter?.trim() || undefined;
+    const { reply, embedOptions } = await getEmbeds(user, ctx.user.id, index, page, isPage, mods, includeFails, titleFilter);
     if (embedOptions) {
         await ctx.sendWithPagination(reply, embedOptions);
     } else {
@@ -87,6 +88,7 @@ async function getEmbeds(
     isPage: boolean,
     mods: any,
     includeFails: boolean,
+    titleFilter: string | undefined,
 ): Promise<{ reply: MessageReplyOptions; embedOptions?: PlaysBuilderOptions }> {
     const osuUserRequest = await safeParse(v2.users.details({ user: user.banchoId, mode: user.mode }));
     if (!osuUserRequest.success) {
@@ -131,6 +133,7 @@ async function getEmbeds(
         page,
         index,
         mods,
+        titleFilter,
         plays,
     };
 
@@ -210,6 +213,11 @@ export const data = {
                 name: "grade",
                 description: "Consider scores only with this grade.",
                 choices: ["SS", "S", "A", "B", "C", "D"].map((grade) => ({ name: grade, value: grade })),
+            },
+            {
+                type: ApplicationCommandOptionType.STRING,
+                name: "filter",
+                description: "Filter plays by beatmap title.",
             },
             {
                 type: ApplicationCommandOptionType.BOOLEAN,

--- a/src/commands/osu/top.ts
+++ b/src/commands/osu/top.ts
@@ -52,7 +52,8 @@ export async function run(ctx: CommandContext) {
     if (typeof page === "undefined" && typeof index === "undefined") page = 0;
     const isPage = typeof page !== "undefined";
 
-    const { reply, embedOptions } = await getEmbeds(user, ctx.user.id, index, page, isPage, mods);
+    const titleFilter = flags.filter?.trim() || undefined;
+    const { reply, embedOptions } = await getEmbeds(user, ctx.user.id, index, page, isPage, mods, titleFilter);
     if (embedOptions) {
         await ctx.sendWithPagination(reply, embedOptions);
     } else {
@@ -67,6 +68,7 @@ async function getEmbeds(
     page: number | undefined,
     isPage: boolean,
     mods: any,
+    titleFilter: string | undefined,
 ): Promise<{ reply: MessageReplyOptions; embedOptions?: PlaysBuilderOptions }> {
     const osuUserRequest = await safeParse(v2.users.details({ user: user.banchoId, mode: user.mode }));
     if (!osuUserRequest.success) {
@@ -111,6 +113,7 @@ async function getEmbeds(
         page,
         index,
         mods,
+        titleFilter,
         plays,
     };
 
@@ -190,6 +193,11 @@ export const data = {
                 name: "grade",
                 description: "Consider scores only with this grade.",
                 choices: ["SS", "S", "A", "B", "C", "D"].map((grade) => ({ name: grade, value: grade })),
+            },
+            {
+                type: ApplicationCommandOptionType.STRING,
+                name: "filter",
+                description: "Filter plays by beatmap title.",
             },
             {
                 type: ApplicationCommandOptionType.USER,

--- a/src/embed-builders/plays.ts
+++ b/src/embed-builders/plays.ts
@@ -2,13 +2,14 @@ import { getFormattedProfile, getFormattedScore } from "@utils/formatter";
 import { SPACE } from "@utils/constants";
 import { EmbedScoreType } from "@type/database";
 import { saveScoreDatas } from "@utils/osu";
+import { filterPlays } from "@utils/play-filters";
 import { EmbedType } from "lilybird";
 import type { User } from "@type/database";
 import type { UserScore, Mode, ProfileInfo, ScoresInfo, UserBestScore, UserScoreV2, UserBestScoreV2 } from "@type/osu";
 import type { PlaysBuilderOptions } from "@type/builders";
 import type { Embed } from "lilybird";
 
-export async function playBuilder({ plays, user, mode, index, mods, isMultiple, page, authorDb, sortByDate }: PlaysBuilderOptions): Promise<Array<Embed.Structure>> {
+export async function playBuilder({ plays, user, mode, index, mods, isMultiple, page, authorDb, sortByDate, titleFilter }: PlaysBuilderOptions): Promise<Array<Embed.Structure>> {
     await saveScoreDatas(plays, mode);
 
     if (typeof page === "undefined" && typeof index === "undefined") {
@@ -17,28 +18,7 @@ export async function playBuilder({ plays, user, mode, index, mods, isMultiple, 
     }
 
     const profile = getFormattedProfile(user, mode);
-
-    if (mods?.name) {
-        const { exclude, forceInclude, include, name } = mods;
-        const filteredPlays: typeof plays = [];
-        for (const play of plays) {
-            const playMods = play.mods.map((mod) => (typeof mod === "string" ? mod : mod.acronym).toUpperCase());
-            const modName = typeof name === "string" ? name : name?.acronym;
-            const requestedMods = typeof modName === "string" ? (modName.toUpperCase().match(/.{1,2}/g) ?? []) : [];
-
-            if (modName) {
-                if (exclude) {
-                    if (!requestedMods.every((requestedMod) => playMods.includes(requestedMod))) filteredPlays.push(play);
-                } else if (forceInclude) {
-                    if (playMods.length === requestedMods.length && requestedMods.every((requestedMod) => playMods.includes(requestedMod))) filteredPlays.push(play);
-                } else if (include) {
-                    if (requestedMods.every((requestedMod) => playMods.includes(requestedMod))) filteredPlays.push(play);
-                }
-            } else filteredPlays.push(play);
-        }
-
-        plays = filteredPlays;
-    }
+    plays = filterPlays(plays, { mods, titleFilter });
 
     if (sortByDate)
         plays = [...plays].sort((a, b) => {

--- a/src/types/builders.ts
+++ b/src/types/builders.ts
@@ -18,11 +18,11 @@ export const enum EmbedBuilderType {
     WHATIF = "whatIfBuilder",
 }
 
-interface ModStructure {
+export interface ModStructure {
     exclude: null | boolean;
     include: null | boolean;
     forceInclude: null | boolean;
-    name: null | Mod;
+    name: null | Mod | string;
 }
 
 export interface BuilderOptions {
@@ -72,6 +72,7 @@ export interface PlaysBuilderOptions extends BuilderOptions {
     page?: number;
     isPage?: boolean;
     mods?: ModStructure;
+    titleFilter?: string;
 }
 
 export interface ProfileBuilderOptions extends BuilderOptions {

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -239,8 +239,15 @@ export async function parseOsuArguments(message: Message, args: Array<string>, m
         args.splice(indexToRemove, 1);
     }
 
-    const newArgs = args.join(" ").match(/(".*?"|\S+)/g) ?? [];
+    const newArgs = args.join(" ").match(/(?:[^\s="]+=".*?"|".*?"|\S+)/g) ?? [];
     for (const arg of newArgs) {
+        const flagMatch = /^([^=\s]+)=(.*)$/.exec(arg);
+        if (flagMatch) {
+            const [, key, rawValue] = flagMatch;
+            result.flags[key] = rawValue.replace(/^"(.*)"$/, "$1");
+            continue;
+        }
+
         if (arg.includes('"')) {
             (result.tempUser ??= []).push(arg.replace(/"/g, ""));
             continue;

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,4 +1,5 @@
 import { ComponentType, ButtonStyle } from "lilybird";
+import { filterPlays } from "@utils/play-filters";
 import type { Message } from "lilybird";
 import type { EmbedBuilderOptions } from "@type/builders";
 
@@ -109,7 +110,7 @@ export class PaginationManager {
         if ("scores" in updatedOptions && Array.isArray(updatedOptions.scores)) {
             totalItems = updatedOptions.scores.length;
         } else if ("plays" in updatedOptions && Array.isArray(updatedOptions.plays)) {
-            totalItems = updatedOptions.plays.length;
+            totalItems = filterPlays(updatedOptions.plays, updatedOptions).length;
         }
 
         if (type === PaginationType.PAGE) {
@@ -140,7 +141,7 @@ export class PaginationManager {
             return options.scores.length;
         }
         if ("plays" in options && Array.isArray(options.plays)) {
-            return options.plays.length;
+            return filterPlays(options.plays, options).length;
         }
         return 0;
     }

--- a/src/utils/play-filters.ts
+++ b/src/utils/play-filters.ts
@@ -1,0 +1,38 @@
+import type { ModStructure } from "@type/builders";
+import type { UserBestScore, UserBestScoreV2, UserScore, UserScoreV2 } from "@type/osu";
+
+export type FilterablePlay = UserBestScore | UserScore | UserBestScoreV2 | UserScoreV2;
+
+interface PlayFilterOptions {
+    mods?: ModStructure;
+    titleFilter?: string | null;
+}
+
+function playMatchesMods(play: FilterablePlay, mods: ModStructure): boolean {
+    const { exclude, forceInclude, include, name } = mods;
+    const modName = typeof name === "string" ? name : name?.acronym;
+    if (!modName) return true;
+
+    const playMods = play.mods.map((mod) => (typeof mod === "string" ? mod : mod.acronym).toUpperCase());
+    const requestedMods = modName.toUpperCase().match(/.{1,2}/g) ?? [];
+
+    if (exclude) return !requestedMods.every((requestedMod) => playMods.includes(requestedMod));
+    if (forceInclude) return playMods.length === requestedMods.length && requestedMods.every((requestedMod) => playMods.includes(requestedMod));
+    if (include) return requestedMods.every((requestedMod) => playMods.includes(requestedMod));
+
+    return true;
+}
+
+function playMatchesTitle(play: FilterablePlay, titleFilter: string): boolean {
+    const normalizedFilter = titleFilter.trim().toLocaleLowerCase();
+    if (!normalizedFilter) return true;
+
+    const titles = [play.beatmapset.title, play.beatmapset.title_unicode].filter((title): title is string => typeof title === "string");
+    return titles.some((title) => title.toLocaleLowerCase().includes(normalizedFilter));
+}
+
+export function filterPlays(plays: Array<FilterablePlay>, { mods, titleFilter }: PlayFilterOptions): Array<FilterablePlay> {
+    if (!mods?.name && !titleFilter) return plays;
+
+    return plays.filter((play) => (!mods?.name || playMatchesMods(play, mods)) && (!titleFilter || playMatchesTitle(play, titleFilter)));
+}

--- a/tests/commands/osu/top.test.ts
+++ b/tests/commands/osu/top.test.ts
@@ -9,6 +9,8 @@ interface ReplyPayload {
     components?: unknown;
 }
 
+const playBuilderMock = mock(() => Promise.resolve([{ title: "top play", author: { name: "mrekk" } }]));
+
 function parseMockBigInt(value: string | number | bigint, fieldName = "value"): bigint {
     if (typeof value === "bigint") return value;
     if (typeof value === "number" && !Number.isSafeInteger(value)) throw new Error(`${fieldName} must be a safe integer or decimal string`);
@@ -48,7 +50,7 @@ mock.module("@utils/score-api", () => ({
 }));
 
 mock.module("@builders", () => ({
-    playBuilder: mock(() => Promise.resolve([{ title: "top play", author: { name: "mrekk" } }])),
+    playBuilder: playBuilderMock,
     simulateBuilder: mock(() => Promise.resolve([{ title: "simulated" }])),
     whatIfBuilder: mock(({ user, projection, projectedRank }: any) => [
         {
@@ -60,6 +62,7 @@ mock.module("@builders", () => ({
 }));
 
 const { run, data: topData } = await import("../../../src/commands/osu/top");
+const { data: recentData } = await import("../../../src/commands/osu/recent");
 const { data: recentBestData } = await import("../../../src/commands/osu/recentbest");
 const { data: recentListData } = await import("../../../src/commands/osu/recentlist");
 
@@ -67,11 +70,22 @@ function getPageMaxValue(commandData: { application: { options: Array<{ name: st
     return commandData.application.options.find((option) => option.name === "page")?.max_value;
 }
 
+function hasFilterOption(commandData: { application: { options: Array<{ name: string }> } }): boolean {
+    return commandData.application.options.some((option) => option.name === "filter");
+}
+
 describe("top command", () => {
     test("allows selecting pages for all fetched top plays", () => {
         expect(getPageMaxValue(topData)).toBe(40);
         expect(getPageMaxValue(recentBestData)).toBe(40);
         expect(getPageMaxValue(recentListData)).toBe(40);
+    });
+
+    test("exposes title filter option on fetched play commands", () => {
+        expect(hasFilterOption(topData)).toBe(true);
+        expect(hasFilterOption(recentData)).toBe(true);
+        expect(hasFilterOption(recentBestData)).toBe(true);
+        expect(hasFilterOption(recentListData)).toBe(true);
     });
 
     test("runs with mocked osu data and returns paginated embeds", async () => {
@@ -95,6 +109,28 @@ describe("top command", () => {
         if (!replyCall) throw new Error("Expected reply payload");
         expect(replyCall.embeds[0].title).toBe("top play");
         expect(replyCall.components).toBeDefined();
+    });
+
+    test("passes prefix title filters to the plays builder", async () => {
+        const mockClient = { rest: {} } as unknown as Client;
+        const reply = mock((_options: ReplyPayload) => Promise.resolve({ edit: mock(() => Promise.resolve({})) }));
+        const mockMessage = {
+            author: { id: "123", username: "test_user" },
+            guildId: "guild",
+            channelId: "channel123",
+            reply,
+        } as unknown as Message;
+
+        playBuilderMock.mockClear();
+
+        const ctx = new CommandContext(mockClient, undefined, mockMessage, ["mrekk", 'filter="Yami', "no", 'Uta"'], "!", "top");
+        ctx.defer = mock(() => Promise.resolve());
+
+        await run(ctx);
+
+        expect(playBuilderMock).toHaveBeenCalled();
+        const [builderOptions] = playBuilderMock.mock.calls[0] as Array<{ titleFilter?: string }>;
+        expect(builderOptions.titleFilter).toBe("Yami no Uta");
     });
 
     test("returns a generic not found embed for a missing user", async () => {

--- a/tests/embed-builders/plays.test.ts
+++ b/tests/embed-builders/plays.test.ts
@@ -19,10 +19,11 @@ mock.module("@utils/formatter", () => ({
         avatarUrl: "https://a.ppy.sh/1",
         flagUrl: "https://osu.ppy.sh/images/flags/TR.png",
     })),
-    getFormattedScore: mock(({ index }: { index: number }) =>
-        Promise.resolve({
+    getFormattedScore: mock(({ scores, index }: { scores: Array<{ beatmapset?: { title?: string } }>; index: number }) => {
+        const songName = scores[index]?.beatmapset?.title ?? `Song ${index + 1}`;
+        return Promise.resolve({
             position: index + 1,
-            songName: `Song ${index + 1}`,
+            songName,
             difficultyName: "Expert",
             mapLink: `https://osu.ppy.sh/beatmaps/${index + 1}`,
             mods: ["HR"],
@@ -34,8 +35,8 @@ mock.module("@utils/formatter", () => ({
             hitValues: "500/0/0",
             comboValues: "1,000/1,000x",
             playSubmitted: "1 day ago",
-        }),
-    ),
+        });
+    }),
 }));
 
 const { playBuilder } = await import("../../src/embed-builders/plays");
@@ -60,5 +61,31 @@ describe("plays embed builder", () => {
         expect(embeds[0]?.footer?.text).toBe("Page 1 of 40");
         expect(embeds[0]?.description).toContain("#1");
         expect(embeds[0]?.description).toContain("#5");
+    });
+
+    test("filters plays by beatmap title before rendering pages", async () => {
+        const plays = [
+            { id: 1, mods: [], beatmapset: { title: "Yami no Uta" } },
+            { id: 2, mods: [], beatmapset: { title: "Another Song" } },
+            { id: 3, mods: [], beatmapset: { title: "Uta ni Katachi wa Nai Keredo" } },
+        ];
+
+        const embeds = await playBuilder({
+            type: EmbedBuilderType.PLAYS,
+            initiatorId: "user-1",
+            user: { id: 1, username: "yorunoken" },
+            mode: Mode.OSU,
+            authorDb: null,
+            isMultiple: true,
+            isPage: true,
+            page: 0,
+            titleFilter: "uta",
+            plays,
+        } as never);
+
+        expect(embeds[0]?.footer?.text).toBe("Page 1 of 1");
+        expect(embeds[0]?.description).toContain("Yami no Uta");
+        expect(embeds[0]?.description).toContain("Uta ni Katachi wa Nai Keredo");
+        expect(embeds[0]?.description).not.toContain("Another Song");
     });
 });

--- a/tests/utils/args.test.ts
+++ b/tests/utils/args.test.ts
@@ -72,6 +72,15 @@ describe("args parser", () => {
             expect(result.mods.name).toBe("HDHR");
         });
 
+        test("parses quoted flag values without treating them as usernames", async () => {
+            const message = { author: { id: "0000" } } as unknown as Message;
+            const result = await parseOsuArguments(message, ["peppy", 'filter="yami', "no", 'uta"'], Mode.OSU);
+
+            expect(result.user.type).toBe(UserType.SUCCESS);
+            if (result.user.type === UserType.SUCCESS) expect(result.user.banchoId).toBe("peppy");
+            expect(result.flags.filter).toBe("yami no uta");
+        });
+
         test("resolves linked Discord mentions through injected database lookup", async () => {
             const message = { author: { id: "0000" } } as unknown as Message;
             const result = await parseOsuArguments(message, ["<@123456789012345678>"], Mode.OSU);


### PR DESCRIPTION
Adds a `filter` option for score-play commands so users can match fetched plays by beatmap title. This applies to top, recent, recentbest, and recentlist, including prefix usage such as `filter=uta` and `filter="yami no uta"`.

The play filtering logic now lives in a shared helper so mods and title filters use the same rules for embed rendering and pagination counts.

Closes #187

Checks run:
- `bun test`
- `bun run check`