### PR TITLE
Add pagination page picker

### DIFF
--- a/src/listeners/interaction-create.ts
+++ b/src/listeners/interaction-create.ts
@@ -3,18 +3,24 @@ import { commandsCache } from "@utils/cache";
 import { logger } from "@utils/logger";
 import { ButtonStateCache } from "@utils/cache";
 import { EmbedBuilderType } from "@type/builders";
-import { createPaginationActionRow } from "@utils/pagination";
+import { createPaginationActionRow, PAGINATION_JUMP_INPUT_ID } from "@utils/pagination";
 import { PaginationManager } from "@utils/pagination";
 import { leaderboardBuilder, playBuilder, compareBuilder } from "@builders";
 import type { Interaction, InteractionReplyOptions } from "@lilybird/transformers";
 import { handleCommandError } from "@utils/error";
 import { CommandContext } from "@utils/command-context";
 import { $listener } from "@utils/lilybird-handler";
+import { ComponentType, TextInputStyle } from "lilybird";
+import type { Message } from "lilybird";
+import type { EmbedBuilderOptions } from "@type/builders";
+
+type PaginationMessageOptions = Pick<InteractionReplyOptions, "embeds" | "components">;
 
 $listener({
     event: "interactionCreate",
     handle: async (interaction) => {
         await handleButton(interaction);
+        await handlePaginationModal(interaction);
 
         if (interaction.isApplicationCommandInteraction()) {
             const command = commandsCache.get(interaction.data.name);
@@ -86,6 +92,22 @@ async function handleButton(interaction: Interaction): Promise<void> {
         return;
     }
 
+    const jumpType = PaginationManager.parseJumpButtonType(interaction.data.id);
+    if (jumpType) {
+        const totalValues = PaginationManager.getTotalValues(PaginationManager.getTotalItems(builderOptions), jumpType);
+        if (totalValues <= 1) {
+            await interaction.reply({ ephemeral: true, content: "There is only one page available." });
+            return;
+        }
+
+        await interaction.showModal({
+            id: PaginationManager.createJumpModalId(jumpType, interaction.message.channelId, interaction.message.id),
+            title: jumpType === "page" ? "Jump to page" : "Jump to entry",
+            components: createPaginationJumpModalComponents(jumpType, totalValues, PaginationManager.getCurrentValue(builderOptions, jumpType)),
+        });
+        return;
+    }
+
     // Temporarily disable all buttons during processing
     const currentComponents = createPaginationActionRow(builderOptions);
     const disabledComponents = currentComponents.map((row: any) => ({
@@ -94,11 +116,6 @@ async function handleButton(interaction: Interaction): Promise<void> {
     }));
 
     await interaction.updateComponents({ components: disabledComponents });
-
-    if (interaction.data.id === "wildcard-page" || interaction.data.id === "wildcard-index") {
-        await interaction.editReply({ content: "This feature has not been implemented yet." });
-        return;
-    }
 
     const buttonAction = PaginationManager.parseButtonAction(interaction.data.id);
     if (!buttonAction) {
@@ -110,9 +127,98 @@ async function handleButton(interaction: Interaction): Promise<void> {
 
     await ButtonStateCache.set(interaction.message.id, updatedOptions);
 
-    const options: InteractionReplyOptions = {};
+    const options = await buildPaginationMessageOptions(updatedOptions);
 
-    // Build the appropriate embed
+    if (!options) {
+        await interaction.editReply({ content: "Unsupported builder type for pagination." });
+        return;
+    }
+
+    await interaction.editReply(options);
+}
+
+async function handlePaginationModal(interaction: Interaction): Promise<void> {
+    if (!interaction.isModalSubmitInteraction()) return;
+
+    const modalData = PaginationManager.parseJumpModalId(interaction.data.id);
+    if (!modalData) return;
+
+    const rawValue = getModalInputValue(interaction.data.components, PAGINATION_JUMP_INPUT_ID);
+    const requestedValue = rawValue ? Number(rawValue.trim()) : Number.NaN;
+
+    const builderOptions = await ButtonStateCache.get(modalData.messageId);
+    if (builderOptions === null || builderOptions === undefined) {
+        await interaction.reply({ ephemeral: true, content: "This page picker will not work because the message was created before a bot restart, so its data has been lost." });
+        return;
+    }
+
+    const user = interaction.inGuild() ? interaction.member.user : interaction.inDM() ? interaction.user : undefined;
+    if (!user) return;
+
+    if (builderOptions.initiatorId !== user.id) {
+        await interaction.reply({ ephemeral: true, content: "You need to be the person who initialized the command to be able to interact with this." });
+        return;
+    }
+
+    const totalValues = PaginationManager.getTotalValues(PaginationManager.getTotalItems(builderOptions), modalData.type);
+
+    if (!Number.isInteger(requestedValue) || requestedValue < 1 || requestedValue > totalValues) {
+        await interaction.reply({ ephemeral: true, content: `Please enter a whole number between 1 and ${totalValues}.` });
+        return;
+    }
+
+    const updatedOptions = PaginationManager.updateBuilderOptionsValue(builderOptions, requestedValue - 1, modalData.type);
+    await ButtonStateCache.set(modalData.messageId, updatedOptions);
+
+    const options = await buildPaginationMessageOptions(updatedOptions);
+    if (!options) {
+        await interaction.reply({ ephemeral: true, content: "Unsupported builder type for pagination." });
+        return;
+    }
+
+    await interaction.updateComponents(options);
+}
+
+function createPaginationJumpModalComponents(type: "page" | "index", totalValues: number, currentValue: number): Array<Message.Component.ActionRowStructure> {
+    const label = type === "page" ? `Page (1-${totalValues})` : `Entry (1-${totalValues})`;
+
+    return [
+        {
+            type: ComponentType.ActionRow,
+            components: [
+                {
+                    type: ComponentType.TextInput,
+                    custom_id: PAGINATION_JUMP_INPUT_ID,
+                    style: TextInputStyle.Short,
+                    label,
+                    min_length: 1,
+                    max_length: String(totalValues).length,
+                    required: true,
+                    value: String(currentValue + 1),
+                    placeholder: String(currentValue + 1),
+                },
+            ],
+        },
+    ];
+}
+
+function getModalInputValue(components: Array<Message.Component.Structure>, inputId: string): string | undefined {
+    for (const component of components) {
+        if (component.type !== ComponentType.ActionRow) continue;
+
+        for (const nestedComponent of component.components) {
+            if (nestedComponent.type === ComponentType.TextInput && nestedComponent.custom_id === inputId) {
+                return nestedComponent.value;
+            }
+        }
+    }
+
+    return undefined;
+}
+
+async function buildPaginationMessageOptions(updatedOptions: EmbedBuilderOptions): Promise<PaginationMessageOptions | null> {
+    const options: PaginationMessageOptions = {};
+
     switch (updatedOptions.type) {
         case EmbedBuilderType.LEADERBOARD:
             options.embeds = await leaderboardBuilder(updatedOptions as any);
@@ -124,12 +230,9 @@ async function handleButton(interaction: Interaction): Promise<void> {
             options.embeds = await compareBuilder(updatedOptions as any);
             break;
         default:
-            await interaction.reply({ ephemeral: true, content: "Unsupported builder type for pagination." });
-            return;
+            return null;
     }
 
-    // Create the action row with proper disabled states
     options.components = createPaginationActionRow(updatedOptions);
-
-    await interaction.editReply(options);
+    return options;
 }

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -4,6 +4,7 @@ import type { Message } from "lilybird";
 import type { EmbedBuilderOptions } from "@type/builders";
 
 export const ITEMS_PER_PAGE = 5;
+export const PAGINATION_JUMP_INPUT_ID = "pagination-jump-value";
 
 export enum PaginationType {
     PAGE = "page",
@@ -24,12 +25,18 @@ interface PaginationConfig {
     itemsPerPage?: number;
 }
 
+interface PaginationJumpModalData {
+    type: PaginationType;
+    channelId: string;
+    messageId: string;
+}
+
 export class PaginationManager {
     private static getButtonConfig(type: PaginationType) {
         const suffix = type === PaginationType.PAGE ? "page" : "index";
         return {
-            customIds: [`min-${suffix}`, `decrement-${suffix}`, `increment-${suffix}`, `max-${suffix}`],
-            labels: ["<<", "<", ">", ">>"],
+            customIds: [`min-${suffix}`, `decrement-${suffix}`, `wildcard-${suffix}`, `increment-${suffix}`, `max-${suffix}`],
+            labels: ["<<", "<", "...", ">", ">>"],
         };
     }
 
@@ -37,11 +44,12 @@ export class PaginationManager {
         const { type, totalItems, currentValue, itemsPerPage = ITEMS_PER_PAGE } = config;
         const { customIds, labels } = this.getButtonConfig(type);
 
-        const totalPages = type === PaginationType.PAGE ? Math.ceil(totalItems / itemsPerPage) : totalItems;
+        const totalPages = this.getTotalValues(totalItems, type, itemsPerPage);
 
         const disabledStates = [
             currentValue === 0, // First button
             currentValue === 0, // Previous button
+            totalPages <= 1, // Jump button
             currentValue >= totalPages - 1, // Next button
             currentValue >= totalPages - 1, // Last button
         ];
@@ -85,8 +93,33 @@ export class PaginationManager {
         return null;
     }
 
+    static parseJumpButtonType(buttonId: string): PaginationType | null {
+        const match = buttonId.match(/^wildcard-(page|index)$/);
+        if (!match) return null;
+        return match[1] === "page" ? PaginationType.PAGE : PaginationType.INDEX;
+    }
+
+    static createJumpModalId(type: PaginationType, channelId: string, messageId: string): string {
+        return `pagination-jump:${type}:${channelId}:${messageId}`;
+    }
+
+    static parseJumpModalId(modalId: string): PaginationJumpModalData | null {
+        const match = modalId.match(/^pagination-jump:(page|index):([^:]+):([^:]+)$/);
+        if (!match) return null;
+
+        return {
+            type: match[1] === "page" ? PaginationType.PAGE : PaginationType.INDEX,
+            channelId: match[2],
+            messageId: match[3],
+        };
+    }
+
+    static getTotalValues(totalItems: number, type: PaginationType, itemsPerPage: number = ITEMS_PER_PAGE): number {
+        return type === PaginationType.PAGE ? Math.ceil(totalItems / itemsPerPage) : totalItems;
+    }
+
     static calculateNewValue(action: PaginationAction, currentValue: number, totalItems: number, type: PaginationType, itemsPerPage: number = ITEMS_PER_PAGE): number {
-        const maxValue = type === PaginationType.PAGE ? Math.ceil(totalItems / itemsPerPage) - 1 : totalItems - 1;
+        const maxValue = this.getTotalValues(totalItems, type, itemsPerPage) - 1;
 
         switch (action) {
             case PaginationAction.FIRST:
@@ -128,6 +161,26 @@ export class PaginationManager {
             updatedOptions.index = newIndex;
 
             // For plays builder, also update isPage flag
+            if ("isPage" in updatedOptions) {
+                updatedOptions.isPage = false;
+            }
+        }
+
+        return updatedOptions as EmbedBuilderOptions;
+    }
+
+    static updateBuilderOptionsValue(options: EmbedBuilderOptions, value: number, type: PaginationType): EmbedBuilderOptions {
+        const updatedOptions = { ...options } as any;
+
+        if (type === PaginationType.PAGE) {
+            updatedOptions.page = value;
+
+            if ("isPage" in updatedOptions) {
+                updatedOptions.isPage = true;
+            }
+        } else {
+            updatedOptions.index = value;
+
             if ("isPage" in updatedOptions) {
                 updatedOptions.isPage = false;
             }

--- a/tests/commands/osu/simulate.test.ts
+++ b/tests/commands/osu/simulate.test.ts
@@ -5,6 +5,14 @@ import type { Client } from "lilybird";
 import type { Message } from "@lilybird/transformers";
 
 const simulateBuilderMock = mock(() => Promise.resolve([{ title: "simulated" }]));
+const playBuilderMock = mock(() => Promise.resolve([{ title: "play" }]));
+const whatIfBuilderMock = mock(({ user, projection, projectedRank }: any) => [
+    {
+        author: { name: user.username },
+        description: `${projection.projectedTotalPp.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}pp #${projectedRank}`,
+        fields: [{ name: "Projected", value: `+\`${projection.ppGain.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}pp\`` }],
+    },
+]);
 interface ReplyPayload {
     embeds: Array<{ title?: string; description?: string }>;
 }
@@ -30,17 +38,14 @@ mock.module("@utils/database", () => ({
 }));
 
 mock.module("@builders", () => ({
+    playBuilder: playBuilderMock,
     simulateBuilder: simulateBuilderMock,
-    whatIfBuilder: mock(({ user, projection, projectedRank }: any) => [
-        {
-            author: { name: user.username },
-            description: `${projection.projectedTotalPp.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}pp #${projectedRank}`,
-            fields: [{ name: "Projected", value: `+\`${projection.ppGain.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}pp\`` }],
-        },
-    ]),
+    whatIfBuilder: whatIfBuilderMock,
 }));
 mock.module("../../../src/embed-builders/index.ts", () => ({
+    playBuilder: playBuilderMock,
     simulateBuilder: simulateBuilderMock,
+    whatIfBuilder: whatIfBuilderMock,
 }));
 mock.module("../../../src/embed-builders/simulate.ts", () => ({
     simulateBuilder: simulateBuilderMock,

--- a/tests/utils/pagination.test.ts
+++ b/tests/utils/pagination.test.ts
@@ -20,6 +20,35 @@ describe("PaginationManager", () => {
         test("returns null for invalid button ids", () => {
             expect(PaginationManager.parseButtonAction("invalid")).toBeNull();
             expect(PaginationManager.parseButtonAction("min-unknown")).toBeNull();
+            expect(PaginationManager.parseButtonAction("wildcard-page")).toBeNull();
+        });
+    });
+
+    describe("parseJumpButtonType", () => {
+        test("correctly parses jump buttons", () => {
+            expect(PaginationManager.parseJumpButtonType("wildcard-page")).toBe(PaginationType.PAGE);
+            expect(PaginationManager.parseJumpButtonType("wildcard-index")).toBe(PaginationType.INDEX);
+        });
+
+        test("returns null for non-jump buttons", () => {
+            expect(PaginationManager.parseJumpButtonType("increment-page")).toBeNull();
+            expect(PaginationManager.parseJumpButtonType("invalid")).toBeNull();
+        });
+    });
+
+    describe("jump modal ids", () => {
+        test("round-trips modal data", () => {
+            const modalId = PaginationManager.createJumpModalId(PaginationType.PAGE, "123", "456");
+            expect(PaginationManager.parseJumpModalId(modalId)).toEqual({
+                type: PaginationType.PAGE,
+                channelId: "123",
+                messageId: "456",
+            });
+        });
+
+        test("returns null for invalid modal ids", () => {
+            expect(PaginationManager.parseJumpModalId("pagination-jump:unknown:123:456")).toBeNull();
+            expect(PaginationManager.parseJumpModalId("invalid")).toBeNull();
         });
     });
 
@@ -66,6 +95,22 @@ describe("PaginationManager", () => {
             expect((updated as any).index).toBe(4);
             expect((updated as any).isPage).toBe(false);
         });
+
+        test("updates options to an exact PAGE value", () => {
+            const options: any = { plays: new Array(20), page: 0, isPage: true };
+            const updated = PaginationManager.updateBuilderOptionsValue(options, 3, PaginationType.PAGE);
+
+            expect((updated as any).page).toBe(3);
+            expect((updated as any).isPage).toBe(true);
+        });
+
+        test("updates options to an exact INDEX value", () => {
+            const options: any = { scores: new Array(20), index: 0, isPage: false };
+            const updated = PaginationManager.updateBuilderOptionsValue(options, 12, PaginationType.INDEX);
+
+            expect((updated as any).index).toBe(12);
+            expect((updated as any).isPage).toBe(false);
+        });
     });
 
     describe("getTotalItems", () => {
@@ -96,8 +141,9 @@ describe("PaginationManager", () => {
             const components = (row[0] as any).components;
             expect(components[0].disabled).toBe(true); // min
             expect(components[1].disabled).toBe(true); // prev
-            expect(components[2].disabled).toBe(false); // next
-            expect(components[3].disabled).toBe(false); // max
+            expect(components[2].disabled).toBe(false); // jump
+            expect(components[3].disabled).toBe(false); // next
+            expect(components[4].disabled).toBe(false); // max
         });
 
         test("disables next and max buttons on last page", () => {
@@ -110,8 +156,32 @@ describe("PaginationManager", () => {
             const components = (row[0] as any).components;
             expect(components[0].disabled).toBe(false); // min
             expect(components[1].disabled).toBe(false); // prev
-            expect(components[2].disabled).toBe(true); // next
-            expect(components[3].disabled).toBe(true); // max
+            expect(components[2].disabled).toBe(false); // jump
+            expect(components[3].disabled).toBe(true); // next
+            expect(components[4].disabled).toBe(true); // max
+        });
+
+        test("disables the jump button when only one page is available", () => {
+            const config = {
+                type: PaginationType.PAGE,
+                totalItems: 3,
+                currentValue: 0,
+            };
+            const row = PaginationManager.createActionRow(config);
+            const components = (row[0] as any).components;
+            expect(components[2].disabled).toBe(true); // jump
+        });
+
+        test("adds a jump button between previous and next", () => {
+            const config = {
+                type: PaginationType.PAGE,
+                totalItems: 20,
+                currentValue: 1,
+            };
+            const row = PaginationManager.createActionRow(config);
+            const components = (row[0] as any).components;
+            expect(components[2].custom_id).toBe("wildcard-page");
+            expect(components[2].label).toBe("...");
         });
     });
 });


### PR DESCRIPTION
Adds a middle `...` pagination button that opens a modal so command initiators can jump directly to a page or entry by entering a number from 1 to the available maximum.

The modal submit path updates the existing paginated message directly, so successful jumps do not show a temporary loading response.

Closes #232.

Tests:
- `bun run check` passed
- `bun test`.